### PR TITLE
nextcloud: update node to v20

### DIFF
--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -211,8 +211,8 @@ in
         # required for recognize app
         ++ lib.optionals cfg.configureRecognize [
           gnumake # installation requirement
-          nodejs_16 # runtime and installation requirement
-          nodejs_16.pkgs.node-pre-gyp # installation requirement
+          nodejs_20 # runtime and installation requirement
+          nodejs_20.pkgs.node-pre-gyp # installation requirement
           python3 # requirement for node-pre-gyp otherwise fails with exit code 236
           util-linux # runtime requirement for taskset
         ];


### PR DESCRIPTION
Resolves the issue of nodejs_16 being EOL upstream in nixpkgs

It seems while https://github.com/nextcloud/recognize/issues/985 is open and possibly being worked on upstream in recognize, a user can work around this via the built-in option to define node location (the use of path will obviously be fragile here to nixpkgs updates, but for now it's working in my testing)

Current settings as per: `/settings/admin/recognize`
![image](https://github.com/SuperSandro2000/nixos-modules/assets/29395089/30186852-83d0-4ac5-9ea2-7b7a3385f5e6)

Happy to wait for upstream to resolve this with said, if that is the preference :+1: 