### PR TITLE
initrd: do not reference options in defaultText which only exist in n…

### DIFF
--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -20,7 +20,7 @@ in
           enable = lib.mkOption {
             type = lib.types.bool;
             default = cfgn.ssh.enable;
-            defaultText = lib.literalExpression "config.${optn.ssh.enable}";
+            defaultText = lib.literalExpression "config.boot.initrd.network.ssh.enable";
             description = ''
               Whether to check if all interface related kernel modules are loaded in initrd.
 


### PR DESCRIPTION
…ixpkgs

## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
