### PR TITLE
postgres: remove hack to install extensions which are in shared_preload_libraries and add proper option for that

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -149,7 +149,7 @@ in toplevel // {
         enable = true;
         configurePgStatStatements = true;
         enableAllPreloadedLibraries = true;
-        preloadAllExtensions = true;
+        preloadAllInstalledExtensions = true;
       };
     };
   };


### PR DESCRIPTION
Now you can easily load eg: pg_tgrm

Thanks Sophie for the hint!
https://c3d2.social/@sophie@catgirl.cloud/114109970398053904

Closes #221

## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
