### PR TITLE
harmonia: fix another 3.0 migration warning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772894835,
-        "narHash": "sha256-CnTYKXOr951kQlz1P8WYeqyhBsTIE4zaxLMF526ubKA=",
+        "lastModified": 1773107925,
+        "narHash": "sha256-eaRystHxXvKDGx8fGxb+KvYIlA8Vcir04BN8WRtAUwE=",
         "owner": "NuschtOS",
         "repo": "nuschtpkgs",
-        "rev": "28375725318664ab6680178f087c66a7a16f5562",
+        "rev": "bd4580aa3b60980cff0ca971ff99763f034d6231",
         "type": "github"
       },
       "original": {

--- a/modules/harmonia.nix
+++ b/modules/harmonia.nix
@@ -26,9 +26,15 @@ in
   # TODO: remove workaround with 26.05
   config = lib.mkIf (cfg.cache.enable or cfg.enable) {
     services = {
-      harmonia.settings = lib.mkIf cfg.recommendedDefaults {
-        bind = "[::]:${toString cfg.port}";
-        priority = 50; # prefer cache.nixos.org
+      harmonia = let
+        settings = lib.mkIf cfg.recommendedDefaults {
+          bind = "[::]:${toString cfg.port}";
+          priority = 50; # prefer cache.nixos.org
+        };
+      in if cfg?cache?enable then {
+        cache = { inherit settings; };
+      } else {
+        inherit settings;
       };
 
       nginx = lib.mkIf cfg.configureNginx {


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
