### PR TITLE
 nvidia: only enable settings on graphical systems, always use nvidia open

### DIFF
--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -18,6 +18,7 @@ in
       nvidia = {
         modesetting.enable = true;
         nvidiaSettings = true;
+        open = true;
       };
     };
 

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -17,7 +17,8 @@ in
       graphics.enable = true;
       nvidia = {
         modesetting.enable = true;
-        nvidiaSettings = true;
+        # option defaults to true and only useful on graphical systems
+        nvidiaSettings = config.services.graphical-desktop.enable;
         open = true;
       };
     };


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
