### PR TITLE
strace: make module obsolete with version 7.0, drop support for 6.3

### DIFF
--- a/modules/strace.nix
+++ b/modules/strace.nix
@@ -13,16 +13,14 @@ in
   config = lib.mkIf cfg.withColors {
     environment.systemPackages = [
       (pkgs.strace.overrideAttrs ({ patches ? [ ], version, ... }: {
-        patches = patches ++ [
+        # TODO: drop module with 26.05
+        patches = patches ++ lib.optionals (lib.versionOlder version "7.0") [
           (let
-            patchVersion = if lib.versionAtLeast version "6.16" then "6.16" else "6.3";
+            patchVersion = "6.16";
           in pkgs.fetchpatch {
             url = "https://github.com/xfgusta/strace-with-colors/raw/v${patchVersion}-1/strace-with-colors.patch";
-            name = "strace-with-colors-${version}.patch";
-            hash = {
-              "6.16" = "sha256-Uw4lOKuEwT6kTwLZYuTqlq64wBHDt5kL5JwV7hdiBNg=";
-              "6.3" = "sha256-gcQldGsRgvGnrDX0zqcLTpEpchNEbCUFdKyii0wetEI=";
-            }.${patchVersion} or (throw "nixos-modules.strace: does not know a patch for strace version ${version}");
+            name = "strace-with-colors-${patchVersion}.patch";
+            hash = "sha256-Uw4lOKuEwT6kTwLZYuTqlq64wBHDt5kL5JwV7hdiBNg=";
           })
         ];
       }))


### PR DESCRIPTION
## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
