### PR TITLE
nix: make remote builder user a system user

### DIFF
--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -79,7 +79,7 @@ in
     # and https://discourse.nixos.org/t/wrapper-to-restrict-builder-access-through-ssh-worth-upstreaming/25834
     users.users.${cfg.remoteBuilder.name} = lib.mkIf cfg.remoteBuilder.enable {
       group = "nogroup";
-      isNormalUser = true;
+      isSystemUser = true;
       openssh.authorizedKeys.keys = map
         (key:
           let


### PR DESCRIPTION
No one wants or should log in with that

## Things done

- [x] Made sure, no settings are changed by default
- [x] Tested changes on a real world deployment
